### PR TITLE
Add logic to sample_lib for UT

### DIFF
--- a/fsw/public_inc/sample_lib.h
+++ b/fsw/public_inc/sample_lib.h
@@ -39,6 +39,27 @@
 /*************************************************************************
 ** Exported Functions
 *************************************************************************/
+
+/************************************************************************/
+/** \brief Library Initialization Function
+**
+**  \par Description
+**        This function is required by CFE to initialize the library
+**        It should be specified in the cfe_es_startup.scr file as part
+**        of loading this library.  It is not directly invoked by
+**        applications.
+**
+**  \par Assumptions, External Events, and Notes:
+**        None
+**
+**  \returns
+**  \retstmt Returns #CFE_SUCCESS if successful \endcode
+**  \endreturns
+**
+*************************************************************************/
+int32 SAMPLE_LibInit(void);
+
+
 /************************************************************************/
 /** \brief Sample Lib Function 
 **  

--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -31,15 +31,20 @@
 #include "sample_lib.h"
 #include "sample_lib_version.h"
 
+/* for "strncpy()" */
+#include <string.h>
+
 /*************************************************************************
 ** Macro Definitions
 *************************************************************************/
 
+#define SAMPLE_LIB_BUFFER_SIZE      16
+
 
 /*************************************************************************
-** Private Function Prototypes
+** Private Data Structures
 *************************************************************************/
-int32 SAMPLE_LibInit(void);
+static char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -49,8 +54,27 @@ int32 SAMPLE_LibInit(void);
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SAMPLE_LibInit(void)
 {
+    /*
+     * Call a C library function, like strcpy(), and test its result.
+     *
+     * This is primary for a unit test example, to have more than
+     * one code path to exercise.
+     *
+     * The specification for strncpy() indicates that it should return
+     * the pointer to the destination buffer, so it should be impossible
+     * for this to ever fail when linked with a compliant C library.
+     */
+    if (strncpy(SAMPLE_Buffer, "SAMPLE DATA", sizeof(SAMPLE_Buffer)-1) !=
+            SAMPLE_Buffer)
+    {
+        return CFE_STATUS_NOT_IMPLEMENTED;
+    }
     
-    OS_printf ("SAMPLE Lib Initialized.  Version %d.%d.%d.%d",
+    /* ensure termination */
+    SAMPLE_Buffer[sizeof(SAMPLE_Buffer)-1] = 0;
+
+
+    OS_printf ("SAMPLE Lib Initialized.  Version %d.%d.%d.%d\n",
                 SAMPLE_LIB_MAJOR_VERSION,
                 SAMPLE_LIB_MINOR_VERSION, 
                 SAMPLE_LIB_REVISION, 
@@ -67,7 +91,7 @@ int32 SAMPLE_LibInit(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SAMPLE_Function( void ) 
 {
-   OS_printf ("SAMPLE_Function called\n");
+   OS_printf ("SAMPLE_Function called, buffer=\'%s\'\n", SAMPLE_Buffer);
 
    return(CFE_SUCCESS);
    


### PR DESCRIPTION
**Describe the contribution**
Fix #8

In order to make a useful library unit test example, the sample_lib itself needs to perform some more interesting work.

In particular it needs at least one external function call on which a code path decision is made, such that the example UT code will have more than one code path to demonstrate.

Additionally, the library should have some internal "global" structure (like real libs would) that contains its state, that the UT can also test/query.

Both objectives can be accomplished with a small string buffer that gets populated with a `strncpy()` call during init, and printed with the "process" command.

Other minor updates for correctness:
- The entry point (`SAMPLE_LibInit`) is not really a "private" function.  It is called from ES when starting up.  As such it should be considered part of the public API.  This moves the prototype to the public API and corrects the comments so it is _not_ labeled as a private function.  Note this is also relevant for unit tests, because the UT will invoke the entry point too.
- Corrects a missing newline on the OS_printf during startup.  This was a long-standing pet peeve.


**Testing performed**
Built code using SIMULATION=native ENABLE_UNIT_TESTS=TRUE 
Confirmed no build issues, execute CFE and confirm that SAMPLE_Lib starts up as normal.
Force a call to the "SAMPLE_Function()" API and confirm that the printf now includes the buffer contents, as such:

`SAMPLE_Function called, buffer='SAMPLE DATA'`

**Expected behavior changes**
No changes of substance.  Added display of the buffer contents to the OS_printf.

**System(s) tested on:**
Ubuntu 18.04 LTS 64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems. Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
