### PR TITLE
Integration Candidate 20191230

### DIFF
--- a/fsw/public_inc/sample_lib.h
+++ b/fsw/public_inc/sample_lib.h
@@ -39,6 +39,27 @@
 /*************************************************************************
 ** Exported Functions
 *************************************************************************/
+
+/************************************************************************/
+/** \brief Library Initialization Function
+**
+**  \par Description
+**        This function is required by CFE to initialize the library
+**        It should be specified in the cfe_es_startup.scr file as part
+**        of loading this library.  It is not directly invoked by
+**        applications.
+**
+**  \par Assumptions, External Events, and Notes:
+**        None
+**
+**  \returns
+**  \retstmt Returns #CFE_SUCCESS if successful \endcode
+**  \endreturns
+**
+*************************************************************************/
+int32 SAMPLE_LibInit(void);
+
+
 /************************************************************************/
 /** \brief Sample Lib Function 
 **  

--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -31,15 +31,20 @@
 #include "sample_lib.h"
 #include "sample_lib_version.h"
 
+/* for "strncpy()" */
+#include <string.h>
+
 /*************************************************************************
 ** Macro Definitions
 *************************************************************************/
 
+#define SAMPLE_LIB_BUFFER_SIZE      16
+
 
 /*************************************************************************
-** Private Function Prototypes
+** Private Data Structures
 *************************************************************************/
-int32 SAMPLE_LibInit(void);
+static char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -49,8 +54,27 @@ int32 SAMPLE_LibInit(void);
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SAMPLE_LibInit(void)
 {
+    /*
+     * Call a C library function, like strcpy(), and test its result.
+     *
+     * This is primary for a unit test example, to have more than
+     * one code path to exercise.
+     *
+     * The specification for strncpy() indicates that it should return
+     * the pointer to the destination buffer, so it should be impossible
+     * for this to ever fail when linked with a compliant C library.
+     */
+    if (strncpy(SAMPLE_Buffer, "SAMPLE DATA", sizeof(SAMPLE_Buffer)-1) !=
+            SAMPLE_Buffer)
+    {
+        return CFE_STATUS_NOT_IMPLEMENTED;
+    }
     
-    OS_printf ("SAMPLE Lib Initialized.  Version %d.%d.%d.%d",
+    /* ensure termination */
+    SAMPLE_Buffer[sizeof(SAMPLE_Buffer)-1] = 0;
+
+
+    OS_printf ("SAMPLE Lib Initialized.  Version %d.%d.%d.%d\n",
                 SAMPLE_LIB_MAJOR_VERSION,
                 SAMPLE_LIB_MINOR_VERSION, 
                 SAMPLE_LIB_REVISION, 
@@ -67,7 +91,7 @@ int32 SAMPLE_LibInit(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SAMPLE_Function( void ) 
 {
-   OS_printf ("SAMPLE_Function called\n");
+   OS_printf ("SAMPLE_Function called, buffer=\'%s\'\n", SAMPLE_Buffer);
 
    return(CFE_SUCCESS);
    


### PR DESCRIPTION
**Describe the contribution**
Fix #8

**Testing performed**
1. Checked out all IC 20191230 branches
1. Built and ran cFS unit tests and OSAL coverage (vxworks and shared)
   1. All passed (although osal_timer_UT occasionally still fails due to a test issue)
1. Make cmdUtils where cFS-GroundSystem expects it
   1. cd tools/cFS-GroundSystem/Subsystems/cmdUtil
   1. make
1. Started Ground system
   1. python3 GroundSystem.py
1. Enabled commands to 127.0.0.1
1. Confirmed telemetry packets received
1. Sent ES and TIME noop commands, confirmed noop message from cFS on Port 1
1. Sent ES power on reset and observed cFS exit

**Expected behavior changes**
See related pull requests

**System(s) tested on**
 - cFS Dev Server 2
 - OS: Ubuntu 18.04
 - Versions: ic-20191230 branches

**Additional context**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC