### PR TITLE
Fix #26, Install unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sample_lib implements SAMPLE_Function, as an example for how to build and link a
 
 - Minor updates (see https://github.com/nasa/sample_lib/pull/14)
 
-### ***OFFICIAL RELEASE: 1.1.0***
+### ***OFFICIAL RELEASE: 1.1.0 - Aquila***
 
 - Minor updates (see https://github.com/nasa/sample_lib/pull/6)
 - Released as part of cFE 6.7.0, Apache 2.0

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(SRCFILE ${LIB_SRC_FILES})
     
     # Add it to the set of tests to run as part of "make test"
     add_test(${TESTNAME} ${TESTNAME}-testrunner)
+    install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
     
 endforeach()
 


### PR DESCRIPTION
**Describe the contribution**
Fix #26
 - Install unit test as part of cmake recipe

**Testing performed**
Normal build with ENABLE_UNIT_TESTS=true, with make install, and ran sample lib unit test from install dir (passed)

**Expected behavior changes**
Sample lib test runner now shows up in expected  install dir

**System(s) tested on**
 - Hardware: cFS Dev VM
 - OS: Ubuntu 18.04
 - Versions: current bundle development branch

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC