### PR TITLE
Close #25, Add build number and baseline to version file

### DIFF
--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -65,8 +65,7 @@ int32 SAMPLE_LibInit(void)
     /* ensure termination */
     SAMPLE_Buffer[sizeof(SAMPLE_Buffer) - 1] = 0;
 
-    OS_printf("SAMPLE Lib Initialized.  Version %d.%d.%d.%d\n", SAMPLE_LIB_MAJOR_VERSION, SAMPLE_LIB_MINOR_VERSION,
-              SAMPLE_LIB_REVISION, SAMPLE_LIB_MISSION_REV);
+    OS_printf("SAMPLE Lib Initialized.%s\n", SAMPLE_LIB_VERSION_STRING);
 
     return CFE_SUCCESS;
 

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -18,23 +18,49 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: sample_lib_version.h
-**
-** Purpose:
-**  The SAMPLE Lib header file containing version number
-**
-** Notes:
-**
 *************************************************************************/
-#ifndef _sample_lib_version_h_
-#define _sample_lib_version_h_
 
-#define SAMPLE_LIB_MAJOR_VERSION 1
-#define SAMPLE_LIB_MINOR_VERSION 1
-#define SAMPLE_LIB_REVISION      4
-#define SAMPLE_LIB_MISSION_REV   0
+/*! @file sample_lib_version.h
+ * @brief Purpose: 
+ * 
+ *  The Sample Lib header file containing version information
+ * 
+ */
+ 
+#ifndef SAMPLE_LIB_VERSION_H
+#define SAMPLE_LIB_VERSION_H
 
-#endif /* _sample_lib_version_h_ */
+/* Development Build Macro Definitions */
+
+#define SAMPLE_LIB_BUILD_NUMBER 26 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_LIB_BUILD_BASELINE "v1.1.0" /*!< Development Build: git tag that is the base for the current development */
+
+/* Version Macro Definitions */
+
+#define SAMPLE_LIB_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define SAMPLE_LIB_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define SAMPLE_LIB_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define SAMPLE_LIB_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+#define SAMPLE_LIB_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
+#define SAMPLE_LIB_STR(x)        SAMPLE_LIB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+
+/*! @brief Development Build Version Number. 
+ * @details Baseline git tag + Number of commits since baseline. @n
+ * See @ref cfsversions for format differences between development and release versions.
+ */
+#define SAMPLE_LIB_VERSION SAMPLE_LIB_BUILD_BASELINE "+dev" SAMPLE_LIB_STR(SAMPLE_LIB_BUILD_NUMBER) 
+
+/*! @brief Development Build Version String.
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
+ * See @ref cfsversions for format differences between development and release versions. 
+*/          
+#define SAMPLE_LIB_VERSION_STRING                                                          \
+    " Sample Lib Development Build "                                                     \
+    SAMPLE_LIB_VERSION                                                                     \
+    ", Last Official Release: v1.1.0"   /* For full support please use this version */
+
+#endif /* SAMPLE_LIB_VERSION_H */
 
 /************************/
 /*  End of File Comment */


### PR DESCRIPTION
**Describe the contribution**
Close #25 

**Testing performed**
Build with bundle

**Expected behavior changes**
Version report now shows development build number
```
1980-012-14:06:58.26153 ES Startup: Loading shared library: /cf/sample_lib.so
SAMPLE Lib Initialized. Sample Lib Development Build v1.1.0+dev26, Last Official Release: v1.1.0
```

**System(s) tested on**
Ubuntu on Docker on OSX

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC