### PR TITLE
Fix #30, Install unit test to target directory

### DIFF
--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -92,7 +92,9 @@ foreach(SRCFILE ${LIB_SRC_FILES})
     
     # Add it to the set of tests to run as part of "make test"
     add_test(${TESTNAME} ${TESTNAME}-testrunner)
-    install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+    foreach(TGT ${INSTALL_TARGET_LIST})
+        install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
+    endforeach()
     
 endforeach()
 


### PR DESCRIPTION
**Describe the contribution**
Fix #30, Install unit test to target directory

**Testing performed**
Make unit tests, install, observe they install in correct directory

**Expected behavior changes**
Correct install directory

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC