### PR TITLE
Fix #33, Standardize to SAMPLE_LIB_ namespace prefix

### DIFF
--- a/fsw/public_inc/sample_lib.h
+++ b/fsw/public_inc/sample_lib.h
@@ -56,7 +56,7 @@
 **
 **
 *************************************************************************/
-int32 SAMPLE_LibInit(void);
+int32 SAMPLE_LIB_Init(void);
 
 /************************************************************************/
 /** \brief Sample Lib Function
@@ -71,7 +71,7 @@ int32 SAMPLE_LibInit(void);
 **
 **
 *************************************************************************/
-int32 SAMPLE_Function(void);
+int32 SAMPLE_LIB_Function(void);
 
 #endif /* _sample_lib_h_ */
 

--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -37,7 +37,7 @@
 /*************************************************************************
 ** Private Data Structures
 *************************************************************************/
-char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
+char SAMPLE_LIB_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -45,7 +45,7 @@ char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 /* cFE requires that a library have an initialization routine      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_LibInit(void)
+int32 SAMPLE_LIB_Init(void)
 {
     /*
      * Call a C library function, like strcpy(), and test its result.
@@ -57,32 +57,32 @@ int32 SAMPLE_LibInit(void)
      * the pointer to the destination buffer, so it should be impossible
      * for this to ever fail when linked with a compliant C library.
      */
-    if (strncpy(SAMPLE_Buffer, "SAMPLE DATA", sizeof(SAMPLE_Buffer) - 1) != SAMPLE_Buffer)
+    if (strncpy(SAMPLE_LIB_Buffer, "SAMPLE DATA", sizeof(SAMPLE_LIB_Buffer) - 1) != SAMPLE_LIB_Buffer)
     {
         return CFE_STATUS_NOT_IMPLEMENTED;
     }
 
     /* ensure termination */
-    SAMPLE_Buffer[sizeof(SAMPLE_Buffer) - 1] = 0;
+    SAMPLE_LIB_Buffer[sizeof(SAMPLE_LIB_Buffer) - 1] = 0;
 
     OS_printf("SAMPLE Lib Initialized.%s\n", SAMPLE_LIB_VERSION_STRING);
 
     return CFE_SUCCESS;
 
-} /* End SAMPLE_LibInit */
+} /* End SAMPLE_LIB_Init */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Sample Lib function                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_Function(void)
+int32 SAMPLE_LIB_Function(void)
 {
-    OS_printf("SAMPLE_Function called, buffer=\'%s\'\n", SAMPLE_Buffer);
+    OS_printf("SAMPLE_LIB_Function called, buffer=\'%s\'\n", SAMPLE_LIB_Buffer);
 
     return (CFE_SUCCESS);
 
-} /* End SAMPLE_Function */
+} /* End SAMPLE_LIB_Function */
 
 /************************/
 /*  End of File Comment */

--- a/fsw/src/sample_lib_internal.h
+++ b/fsw/src/sample_lib_internal.h
@@ -41,7 +41,7 @@
 /*************************************************************************
 ** Internal Data Structures
 *************************************************************************/
-extern char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
+extern char SAMPLE_LIB_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 
 /*************************************************************************
 ** Function Declarations
@@ -50,7 +50,7 @@ extern char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 /**
  * Library initialization routine/entry point
  */
-int32 SAMPLE_LibInit(void);
+int32 SAMPLE_LIB_Init(void);
 
 #endif /* _sample_lib_internal_h_ */
 

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -59,7 +59,7 @@ typedef struct
     bool format_string_valid;
     bool printf_content_valid;
 
-} SAMPLE_Function_TestState_t;
+} SAMPLE_LIB_Function_TestState_t;
 
 /*
  * A local helper (hook) function for the OS_printf stub provided by OSAL.
@@ -68,7 +68,7 @@ typedef struct
 static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context,
                             va_list va)
 {
-    SAMPLE_Function_TestState_t *State = UserObj;
+    SAMPLE_LIB_Function_TestState_t *State = UserObj;
 
     /*
      * The OS_printf() stub passes format string as the argument
@@ -76,7 +76,7 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
      * detail would not be needed, but this serves as an example
      * of how it can be done.
      */
-    if (Context->ArgCount > 0 && strcmp(Context->ArgPtr[0], "SAMPLE_Function called, buffer=\'%s\'\n") == 0)
+    if (Context->ArgCount > 0 && strcmp(Context->ArgPtr[0], "SAMPLE_LIB_Function called, buffer=\'%s\'\n") == 0)
     {
         State->format_string_valid = true;
 
@@ -101,11 +101,11 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
 **********************************************************************************
 */
 
-void Test_SAMPLE_LibInit(void)
+void Test_SAMPLE_LIB_Init(void)
 {
     /*
      * Test Case For:
-     * int32 SAMPLE_LibInit( void )
+     * int32 SAMPLE_LIB_Init( void )
      */
 
     /* Set a data buffer for strncpy()
@@ -113,7 +113,7 @@ void Test_SAMPLE_LibInit(void)
     UT_SetDataBuffer(UT_KEY(OCS_strncpy), UT_TESTBUFFER, sizeof(UT_TESTBUFFER), false);
 
     /* nominal case should return SUCCESS */
-    UT_TEST_FUNCTION_RC(SAMPLE_LibInit(), CFE_SUCCESS);
+    UT_TEST_FUNCTION_RC(SAMPLE_LIB_Init(), CFE_SUCCESS);
 
     /* A simple confirmation that "OS_printf" was invoked
      * exactly 1 time during the previous function call  */
@@ -126,22 +126,22 @@ void Test_SAMPLE_LibInit(void)
      * This requires use of the local accessor routine to get to the
      * internal buffer, which is declared "static"
      */
-    UtAssert_StrCmp(UT_TESTBUFFER, SAMPLE_Buffer, "Internal buffer content valid");
+    UtAssert_StrCmp(UT_TESTBUFFER, SAMPLE_LIB_Buffer, "Internal buffer content valid");
 
     /* Test failure of the underlying library call */
     UT_SetForceFail(UT_KEY(OCS_strncpy), -1);
 
     /* off-nominal case should return CFE_STATUS_NOT_IMPLEMENTED */
-    UT_TEST_FUNCTION_RC(SAMPLE_LibInit(), CFE_STATUS_NOT_IMPLEMENTED);
+    UT_TEST_FUNCTION_RC(SAMPLE_LIB_Init(), CFE_STATUS_NOT_IMPLEMENTED);
 }
 
-void Test_SAMPLE_Function(void)
+void Test_SAMPLE_LIB_Function(void)
 {
     /*
      * Test Case For:
-     * void SAMPLE_Function( void )
+     * void SAMPLE_LIB_Function( void )
      */
-    SAMPLE_Function_TestState_t state;
+    SAMPLE_LIB_Function_TestState_t state;
 
     /*
      * This function has no conditionals, but it does call
@@ -153,7 +153,7 @@ void Test_SAMPLE_Function(void)
     /*
      * Invoke the actual function
      */
-    SAMPLE_Function();
+    SAMPLE_LIB_Function();
 
     /*
      * Make sure that the extra conditions checked by the
@@ -181,6 +181,6 @@ void Sample_UT_TearDown(void) {}
  */
 void UtTest_Setup(void)
 {
-    ADD_TEST(SAMPLE_LibInit);
-    ADD_TEST(SAMPLE_Function);
+    ADD_TEST(SAMPLE_LIB_Init);
+    ADD_TEST(SAMPLE_LIB_Function);
 }

--- a/ut-stubs/sample_lib_stubs.c
+++ b/ut-stubs/sample_lib_stubs.c
@@ -52,7 +52,7 @@
 /* Sample Init function stub                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_LibInit(void)
+int32 SAMPLE_LIB_Init(void)
 {
     /*
      * The UT_DEFAULT_IMPL macro is generally sufficient
@@ -62,16 +62,16 @@ int32 SAMPLE_LibInit(void)
      * The default return value is 0, unless the test
      * case configures something different.
      */
-    return UT_DEFAULT_IMPL(SAMPLE_LibInit);
+    return UT_DEFAULT_IMPL(SAMPLE_LIB_Init);
 
-} /* End SAMPLE_LibInit */
+} /* End SAMPLE_LIB_Init */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Sample Lib function stub                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_Function(void)
+int32 SAMPLE_LIB_Function(void)
 {
-    return UT_DEFAULT_IMPL(SAMPLE_Function);
-} /* End SAMPLE_Function */
+    return UT_DEFAULT_IMPL(SAMPLE_LIB_Function);
+} /* End SAMPLE_LIB_Function */


### PR DESCRIPTION
**Describe the contribution**
Replace inconsistent SAMPLE_ And SAMPLE_Lib prefixes, now all identifiers should start with SAMPLE_LIB_.

Fixes #33 

**Testing performed**
Build and sanity test CFE
Run all unit tests

**Expected behavior changes**
No impact to behavior, but this also changes the name of the init function from `SAMPLE_LibInit` to `SAMPLE_LIB_Init` which affects the CFE startup script.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Needs to be merged with nasa/sample_app#100

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
