### PR TITLE
Integration Candidate: 2020-11-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ sample_lib implements SAMPLE_Function, as an example for how to build and link a
 
 ## Version History
 
+### Development Build: v1.2.0-rc1+dev8
+
+- No behavior changes. All identifiers now use the prefix `SAMPLE_LIB_`. Changes the name of the init function from SAMPLE_LibInit to SAMPLE_LIB_Init which affects the CFE startup script.
+- Set REVISION to "99" to indicate development version status
+- See <https://github.com/nasa/sample_lib/pull/35>
+
 ### Development Build: v1.2.0-rc1+dev3
 
 - Installs unit test to target directory.
@@ -27,8 +33,8 @@ sample_lib implements SAMPLE_Function, as an example for how to build and link a
 ### Development Build: 1.1.3
 
 - Coverage data `make lcov` includes the sample_lib code
-- See <https://github.com/nasa/sample_lib/pull/22> 
- 
+- See <https://github.com/nasa/sample_lib/pull/22>
+
 ### Development Build: 1.1.2
 
 - Added coverage test and a stub library to facilitate unit test

--- a/fsw/public_inc/sample_lib.h
+++ b/fsw/public_inc/sample_lib.h
@@ -56,7 +56,7 @@
 **
 **
 *************************************************************************/
-int32 SAMPLE_LibInit(void);
+int32 SAMPLE_LIB_Init(void);
 
 /************************************************************************/
 /** \brief Sample Lib Function
@@ -71,7 +71,7 @@ int32 SAMPLE_LibInit(void);
 **
 **
 *************************************************************************/
-int32 SAMPLE_Function(void);
+int32 SAMPLE_LIB_Function(void);
 
 #endif /* _sample_lib_h_ */
 

--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -37,7 +37,7 @@
 /*************************************************************************
 ** Private Data Structures
 *************************************************************************/
-char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
+char SAMPLE_LIB_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -45,7 +45,7 @@ char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 /* cFE requires that a library have an initialization routine      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_LibInit(void)
+int32 SAMPLE_LIB_Init(void)
 {
     /*
      * Call a C library function, like strcpy(), and test its result.
@@ -57,32 +57,32 @@ int32 SAMPLE_LibInit(void)
      * the pointer to the destination buffer, so it should be impossible
      * for this to ever fail when linked with a compliant C library.
      */
-    if (strncpy(SAMPLE_Buffer, "SAMPLE DATA", sizeof(SAMPLE_Buffer) - 1) != SAMPLE_Buffer)
+    if (strncpy(SAMPLE_LIB_Buffer, "SAMPLE DATA", sizeof(SAMPLE_LIB_Buffer) - 1) != SAMPLE_LIB_Buffer)
     {
         return CFE_STATUS_NOT_IMPLEMENTED;
     }
 
     /* ensure termination */
-    SAMPLE_Buffer[sizeof(SAMPLE_Buffer) - 1] = 0;
+    SAMPLE_LIB_Buffer[sizeof(SAMPLE_LIB_Buffer) - 1] = 0;
 
     OS_printf("SAMPLE Lib Initialized.%s\n", SAMPLE_LIB_VERSION_STRING);
 
     return CFE_SUCCESS;
 
-} /* End SAMPLE_LibInit */
+} /* End SAMPLE_LIB_Init */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Sample Lib function                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_Function(void)
+int32 SAMPLE_LIB_Function(void)
 {
-    OS_printf("SAMPLE_Function called, buffer=\'%s\'\n", SAMPLE_Buffer);
+    OS_printf("SAMPLE_LIB_Function called, buffer=\'%s\'\n", SAMPLE_LIB_Buffer);
 
     return (CFE_SUCCESS);
 
-} /* End SAMPLE_Function */
+} /* End SAMPLE_LIB_Function */
 
 /************************/
 /*  End of File Comment */

--- a/fsw/src/sample_lib_internal.h
+++ b/fsw/src/sample_lib_internal.h
@@ -41,7 +41,7 @@
 /*************************************************************************
 ** Internal Data Structures
 *************************************************************************/
-extern char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
+extern char SAMPLE_LIB_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 
 /*************************************************************************
 ** Function Declarations
@@ -50,7 +50,7 @@ extern char SAMPLE_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 /**
  * Library initialization routine/entry point
  */
-int32 SAMPLE_LibInit(void);
+int32 SAMPLE_LIB_Init(void);
 
 #endif /* _sample_lib_internal_h_ */
 

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -21,44 +21,47 @@
 *************************************************************************/
 
 /*! @file sample_lib_version.h
- * @brief Purpose: 
- * 
+ * @brief Purpose:
+ *
  *  The Sample Lib header file containing version information
- * 
+ *
  */
- 
+
 #ifndef SAMPLE_LIB_VERSION_H
 #define SAMPLE_LIB_VERSION_H
 
 /* Development Build Macro Definitions */
 
 #define SAMPLE_LIB_BUILD_NUMBER 3 /*!< Development Build: Number of commits since baseline */
-#define SAMPLE_LIB_BUILD_BASELINE "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_LIB_BUILD_BASELINE \
+    "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */
 
 #define SAMPLE_LIB_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define SAMPLE_LIB_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define SAMPLE_LIB_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
-#define SAMPLE_LIB_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+#define SAMPLE_LIB_REVISION                                                                                         \
+    99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. Value of "99" indicates an unreleased \
+          development version.  */
+#define SAMPLE_LIB_MISSION_REV 0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
 
 #define SAMPLE_LIB_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
-#define SAMPLE_LIB_STR(x)        SAMPLE_LIB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+#define SAMPLE_LIB_STR(x) \
+    SAMPLE_LIB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
 
-/*! @brief Development Build Version Number. 
+/*! @brief Development Build Version Number.
  * @details Baseline git tag + Number of commits since baseline. @n
  * See @ref cfsversions for format differences between development and release versions.
  */
-#define SAMPLE_LIB_VERSION SAMPLE_LIB_BUILD_BASELINE "+dev" SAMPLE_LIB_STR(SAMPLE_LIB_BUILD_NUMBER) 
+#define SAMPLE_LIB_VERSION SAMPLE_LIB_BUILD_BASELINE "+dev" SAMPLE_LIB_STR(SAMPLE_LIB_BUILD_NUMBER)
 
 /*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
- * See @ref cfsversions for format differences between development and release versions. 
-*/          
-#define SAMPLE_LIB_VERSION_STRING                                                          \
-    " Sample Lib DEVELOPMENT BUILD "                                                     \
-    SAMPLE_LIB_VERSION                                                                     \
-    ", Last Official Release: v1.1.0"   /* For full support please use this version */
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
+ * official version. @n See @ref cfsversions for format differences between development and release versions.
+ */
+#define SAMPLE_LIB_VERSION_STRING                       \
+    " Sample Lib DEVELOPMENT BUILD " SAMPLE_LIB_VERSION \
+    ", Last Official Release: v1.1.0" /* For full support please use this version */
 
 #endif /* SAMPLE_LIB_VERSION_H */
 

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -32,7 +32,7 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_LIB_BUILD_NUMBER 3 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_LIB_BUILD_NUMBER 8 /*!< Development Build: Number of commits since baseline */
 #define SAMPLE_LIB_BUILD_BASELINE \
     "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -59,7 +59,7 @@ typedef struct
     bool format_string_valid;
     bool printf_content_valid;
 
-} SAMPLE_Function_TestState_t;
+} SAMPLE_LIB_Function_TestState_t;
 
 /*
  * A local helper (hook) function for the OS_printf stub provided by OSAL.
@@ -68,7 +68,7 @@ typedef struct
 static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context,
                             va_list va)
 {
-    SAMPLE_Function_TestState_t *State = UserObj;
+    SAMPLE_LIB_Function_TestState_t *State = UserObj;
 
     /*
      * The OS_printf() stub passes format string as the argument
@@ -76,7 +76,7 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
      * detail would not be needed, but this serves as an example
      * of how it can be done.
      */
-    if (Context->ArgCount > 0 && strcmp(Context->ArgPtr[0], "SAMPLE_Function called, buffer=\'%s\'\n") == 0)
+    if (Context->ArgCount > 0 && strcmp(Context->ArgPtr[0], "SAMPLE_LIB_Function called, buffer=\'%s\'\n") == 0)
     {
         State->format_string_valid = true;
 
@@ -101,11 +101,11 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
 **********************************************************************************
 */
 
-void Test_SAMPLE_LibInit(void)
+void Test_SAMPLE_LIB_Init(void)
 {
     /*
      * Test Case For:
-     * int32 SAMPLE_LibInit( void )
+     * int32 SAMPLE_LIB_Init( void )
      */
 
     /* Set a data buffer for strncpy()
@@ -113,7 +113,7 @@ void Test_SAMPLE_LibInit(void)
     UT_SetDataBuffer(UT_KEY(OCS_strncpy), UT_TESTBUFFER, sizeof(UT_TESTBUFFER), false);
 
     /* nominal case should return SUCCESS */
-    UT_TEST_FUNCTION_RC(SAMPLE_LibInit(), CFE_SUCCESS);
+    UT_TEST_FUNCTION_RC(SAMPLE_LIB_Init(), CFE_SUCCESS);
 
     /* A simple confirmation that "OS_printf" was invoked
      * exactly 1 time during the previous function call  */
@@ -126,22 +126,22 @@ void Test_SAMPLE_LibInit(void)
      * This requires use of the local accessor routine to get to the
      * internal buffer, which is declared "static"
      */
-    UtAssert_StrCmp(UT_TESTBUFFER, SAMPLE_Buffer, "Internal buffer content valid");
+    UtAssert_StrCmp(UT_TESTBUFFER, SAMPLE_LIB_Buffer, "Internal buffer content valid");
 
     /* Test failure of the underlying library call */
     UT_SetForceFail(UT_KEY(OCS_strncpy), -1);
 
     /* off-nominal case should return CFE_STATUS_NOT_IMPLEMENTED */
-    UT_TEST_FUNCTION_RC(SAMPLE_LibInit(), CFE_STATUS_NOT_IMPLEMENTED);
+    UT_TEST_FUNCTION_RC(SAMPLE_LIB_Init(), CFE_STATUS_NOT_IMPLEMENTED);
 }
 
-void Test_SAMPLE_Function(void)
+void Test_SAMPLE_LIB_Function(void)
 {
     /*
      * Test Case For:
-     * void SAMPLE_Function( void )
+     * void SAMPLE_LIB_Function( void )
      */
-    SAMPLE_Function_TestState_t state;
+    SAMPLE_LIB_Function_TestState_t state;
 
     /*
      * This function has no conditionals, but it does call
@@ -153,7 +153,7 @@ void Test_SAMPLE_Function(void)
     /*
      * Invoke the actual function
      */
-    SAMPLE_Function();
+    SAMPLE_LIB_Function();
 
     /*
      * Make sure that the extra conditions checked by the
@@ -181,6 +181,6 @@ void Sample_UT_TearDown(void) {}
  */
 void UtTest_Setup(void)
 {
-    ADD_TEST(SAMPLE_LibInit);
-    ADD_TEST(SAMPLE_Function);
+    ADD_TEST(SAMPLE_LIB_Init);
+    ADD_TEST(SAMPLE_LIB_Function);
 }

--- a/ut-stubs/sample_lib_stubs.c
+++ b/ut-stubs/sample_lib_stubs.c
@@ -52,7 +52,7 @@
 /* Sample Init function stub                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_LibInit(void)
+int32 SAMPLE_LIB_Init(void)
 {
     /*
      * The UT_DEFAULT_IMPL macro is generally sufficient
@@ -62,16 +62,16 @@ int32 SAMPLE_LibInit(void)
      * The default return value is 0, unless the test
      * case configures something different.
      */
-    return UT_DEFAULT_IMPL(SAMPLE_LibInit);
+    return UT_DEFAULT_IMPL(SAMPLE_LIB_Init);
 
-} /* End SAMPLE_LibInit */
+} /* End SAMPLE_LIB_Init */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Sample Lib function stub                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SAMPLE_Function(void)
+int32 SAMPLE_LIB_Function(void)
 {
-    return UT_DEFAULT_IMPL(SAMPLE_Function);
-} /* End SAMPLE_Function */
+    return UT_DEFAULT_IMPL(SAMPLE_LIB_Function);
+} /* End SAMPLE_LIB_Function */


### PR DESCRIPTION
**Describe the contribution**
Fix #33, Standardize to SAMPLE_LIB_ namespace prefix

**Testing performed**
See framework-bundle CI: https://github.com/nasa/cFS/pull/154/checks

**Expected behavior changes**

PR #34 -  No behavior changes. All identifiers now use the prefix `SAMPLE_LIB_`. Changes the name of the init function from SAMPLE_LibInit to SAMPLE_LIB_Init which affects the CFE startup script.

**System(s) tested on**
Ubuntu CI 

**Additional context**
Part of https://github.com/nasa/cFS/pull/154

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 