### PR TITLE
Fix #36, Refactor UT_SetForceFail to UT_SetDefaultReturnValue

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -129,7 +129,7 @@ void Test_SAMPLE_LIB_Init(void)
     UtAssert_StrCmp(UT_TESTBUFFER, SAMPLE_LIB_Buffer, "Internal buffer content valid");
 
     /* Test failure of the underlying library call */
-    UT_SetForceFail(UT_KEY(OCS_strncpy), -1);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_strncpy), -1);
 
     /* off-nominal case should return CFE_STATUS_NOT_IMPLEMENTED */
     UT_TEST_FUNCTION_RC(SAMPLE_LIB_Init(), CFE_STATUS_NOT_IMPLEMENTED);


### PR DESCRIPTION
Describe the contribution
Fixes #36 by changing UT_SetForceFail to UT_SetDefaultReturnValue

Testing performed
Build and run unit test

Expected behavior changes
No impact to behavior

System(s) tested on
Ubuntu 20.04

Additional context
Dependant on nasa/osal#646

Contributor Info - All information REQUIRED for consideration of pull request
Alex Campbell - NASA/GSFC