### PR TITLE
sample_lib Integration Candidate: 2020-11-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ sample_lib implements SAMPLE_Function, as an example for how to build and link a
 
 ## Version History
 
+### Development Build: v1.2.0-rc1+dev10
+
+- Rename `UT_SetForceFail` to `UT_SetDefaultReturnValue` since some functions that retain more than 1 value are not necessarily failing
+- See <https://github.com/nasa/sample_lib/pull/38>
+
 ### Development Build: v1.2.0-rc1+dev8
 
 - No behavior changes. All identifiers now use the prefix `SAMPLE_LIB_`. Changes the name of the init function from SAMPLE_LibInit to SAMPLE_LIB_Init which affects the CFE startup script.

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -32,7 +32,7 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_LIB_BUILD_NUMBER 8 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_LIB_BUILD_NUMBER 10 /*!< Development Build: Number of commits since baseline */
 #define SAMPLE_LIB_BUILD_BASELINE \
     "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -129,7 +129,7 @@ void Test_SAMPLE_LIB_Init(void)
     UtAssert_StrCmp(UT_TESTBUFFER, SAMPLE_LIB_Buffer, "Internal buffer content valid");
 
     /* Test failure of the underlying library call */
-    UT_SetForceFail(UT_KEY(OCS_strncpy), -1);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_strncpy), -1);
 
     /* off-nominal case should return CFE_STATUS_NOT_IMPLEMENTED */
     UT_TEST_FUNCTION_RC(SAMPLE_LIB_Init(), CFE_STATUS_NOT_IMPLEMENTED);


### PR DESCRIPTION
**Describe the contribution**
Fix #36, Refactor UT_SetForceFail to UT_SetDefaultReturnValue

**Testing performed**
See events for "github actions test" at <https://github.com/astrogeco/cFS/actions>

**Expected behavior changes**
PR #37 - Rename `UT_SetForceFail` to `UT_SetDefaultReturnValue` since some functions that retain more than 1 value are not necessarily failing

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/158>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@zanzaben 