### PR TITLE
Fix #46, simplify build to use wrappers and interface libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,12 @@
-cmake_minimum_required(VERSION 2.6.4)
 project(CFE_SAMPLE_LIB C)
 
-include_directories(fsw/public_inc)
-
-# The shared OSAL and cFE include directories should always be used
-# Note that this intentionally does NOT include PSP-specific includes, just the generic
-include_directories(${CFECORE_SOURCE_DIR}/src/inc)
-include_directories(${CFEPSP_SOURCE_DIR}/fsw/inc)
-
-aux_source_directory(fsw/src LIB_SRC_FILES)
-
 # Create the app module
-add_cfe_app(sample_lib ${LIB_SRC_FILES})
+add_cfe_app(sample_lib fsw/src/sample_lib.c)
+
+# The API to this library (which may be invoked/referenced from other apps)
+# is stored in fsw/public_inc.  Using "target_include_directories" is the 
+# preferred method of indicating this (vs. directory-scope "include_directories").
+target_include_directories(sample_lib PUBLIC fsw/public_inc)
 
 if (ENABLE_UNIT_TESTS)
   add_subdirectory(ut-stubs)

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -15,9 +15,6 @@
 # - "coveragetest" contains source code for the actual unit test cases
 #    The primary objective is to get line/path coverage on the FSW 
 #    code units.
-# - "wrappers" contains wrappers for the FSW code.  The wrapper adds
-#    any UT-specific scaffolding to facilitate the coverage test, and
-#    includes the unmodified FSW source file.
 # - "overrides" provides implementation of LOCAL stub functions to
 #    that replace external calls.  This is for use cases where the
 #    normal link-time  replacements is not sufficient/possible, and
@@ -28,73 +25,44 @@
 # it is primarily for cases where a C library function needs to be
 # overridden.  It's use-case is included here as an example.
 
-
-set(UT_NAME sample_lib)
-
-# Use the UT_Assert public API
 # This is also allowed to directly include files in the "fsw/src"
 # directory that are normally private to the implementation
-include_directories(${osal_MISSION_DIR}/ut_assert/inc)
 include_directories(${PROJECT_SOURCE_DIR}/fsw/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
 # The "overrides" target provides replacements for C library
 # calls that cannot be handled at link time.  Most UT test
 # cases will NOT need this feature.
-add_library(ut_${UT_NAME}_overrides STATIC
+add_cfe_coverage_stubs(sample_lib_overrides
     override_src/libc_string_stubs.c
 )
 
-# The LIB_SRC_FILES variable should contain the list of source files for the FSW build
-# This assumes a 1:1 relationship between FSW source units and coverage tests
-# Generate a dedicated "testrunner" executable that executes the tests for each FSW code unit
-# Although sample_lib has only one source file, this is done in a loop such that 
-# the general pattern should work for several files as well.
-foreach(SRCFILE ${LIB_SRC_FILES})
-    get_filename_component(UNITNAME "${SRCFILE}" NAME_WE)
-    
-    set(TESTNAME                "${UT_NAME}-${UNITNAME}")
-    set(UNIT_SOURCE_FILE        "${CFE_SAMPLE_LIB_SOURCE_DIR}/fsw/src/${UNITNAME}.c")
-    set(TESTCASE_SOURCE_FILE    "coveragetest/coveragetest_${UNITNAME}.c")
-    
-    # Compile the source unit under test as a OBJECT
-    add_library(ut_${TESTNAME}_object OBJECT
-        ${UNIT_SOURCE_FILE}
-    )    
-    
-    # Apply the UT_COVERAGE_COMPILE_FLAGS to the units under test
-    # This should enable coverage analysis on platforms that support this
-    target_compile_options(ut_${TESTNAME}_object PRIVATE ${UT_COVERAGE_COMPILE_FLAGS})
-        
-    # For this object target only, the "override" includes should be injected
-    # into the include path BEFORE any other include path.  This is so the
-    # override will take precedence over any system-provided version.
-    target_include_directories(ut_${TESTNAME}_object PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/override_inc)
-        
-    # Compile a test runner application, which contains the
-    # actual coverage test code (test cases) and the unit under test
-    add_executable(${TESTNAME}-testrunner
-        ${TESTCASE_SOURCE_FILE}
-        $<TARGET_OBJECTS:ut_${TESTNAME}_object>
-    )
-    
-    # This also needs to be linked with UT_COVERAGE_LINK_FLAGS (for coverage)
-    # This is also linked with any other stub libraries needed,
-    # as well as the UT assert framework    
-    target_link_libraries(${TESTNAME}-testrunner
-        ${UT_COVERAGE_LINK_FLAGS}
-        ut_${UT_NAME}_stubs
-        ut_${UT_NAME}_overrides
-        ut_cfe-core_stubs
-        ut_assert
-    )
-    
-    # Add it to the set of tests to run as part of "make test"
-    add_test(${TESTNAME} ${TESTNAME}-testrunner)
-    foreach(TGT ${INSTALL_TARGET_LIST})
-        install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
-    endforeach()
-    
-endforeach()
+# Add a coverate test excutable called "sample_lib-ALL" that 
+# covers all of the functions in sample_lib.  
+#
+# Also note in a more complex app/lib the coverage test can also
+# be broken down into smaller units (in which case one should use
+# a unique suffix other than "ALL" for each unit).  For example,
+# OSAL implements a separate coverage test per source unit.
+add_cfe_coverage_test(sample_lib ALL 
+    "coveragetest/coveragetest_sample_lib.c"
+    "${CFE_SAMPLE_LIB_SOURCE_DIR}/fsw/src/sample_lib.c"
+)
+
+# For the object target only, the "override" includes should be injected
+# into the include path.  Note it is important that this is only included 
+# for the specific unit under test (object lib) not the coverage
+# test executable or test cases, since these typically need the real
+# version of these functions.
+add_cfe_coverage_unit_include(sample_lib ALL
+    ${CMAKE_CURRENT_SOURCE_DIR}/override_inc
+)
+
+
+# The sample_lib stubs out a C library function so must be linked
+# with the local "overrides" library (this is mainly just an example of how this 
+# can be done).
+add_cfe_coverage_dependency(sample_lib ALL 
+    sample_lib_overrides
+)
 

--- a/ut-stubs/CMakeLists.txt
+++ b/ut-stubs/CMakeLists.txt
@@ -9,15 +9,5 @@
 #
 ##################################################################
 
-# Use the UT assert public headers 
-include_directories(${osal_MISSION_DIR}/ut_assert/inc)
-
-# Create a static library containing all stubs.
-#
-# There should be a 1:1 relationship between application source files
-# and the stub files.  Each stub file should provide the same set of
-# functions that the application source file provides.
-add_library(ut_sample_lib_stubs STATIC 
-    sample_lib_stubs.c
-)
+add_cfe_coverage_stubs(sample_lib sample_lib_stubs.c)
 


### PR DESCRIPTION
**Describe the contribution**
Use the wrapper functions now provided by CFE to simplify the
build recipe and work with interface libraries

Fixes #46

**Testing performed**
Build and run CFE unit tests

**Expected behavior changes**
Unit test targets are named a little differently when using the wrapper functions, but transparent if running via ctest.  The filename is different if running manually though.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Requires nasa/cfe#1207 and must be merged before nasa/cfe#1203 to avoid breaking UT

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
