### PR TITLE
Fix #51, Use quotes for local includes

### DIFF
--- a/fsw/src/sample_lib_internal.h
+++ b/fsw/src/sample_lib_internal.h
@@ -30,7 +30,7 @@
 #define _sample_lib_internal_h_
 
 /* Include all external/public definitions */
-#include <sample_lib.h>
+#include "sample_lib.h"
 
 /*************************************************************************
 ** Macro Definitions

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -45,7 +45,7 @@
  * as well as the normal system string.h.  It is differentiated
  * by explicitly specifying the "overrides/" prefix here.
  */
-#include <OCS_string.h>
+#include "OCS_string.h"
 #include <stdbool.h>
 #include <stdarg.h>
 

--- a/unit-test/coveragetest/sample_lib_coveragetest_common.h
+++ b/unit-test/coveragetest/sample_lib_coveragetest_common.h
@@ -32,15 +32,15 @@
  * Includes
  */
 
-#include <utassert.h>
-#include <uttest.h>
-#include <utstubs.h>
+#include "utassert.h"
+#include "uttest.h"
+#include "utstubs.h"
 
 /*
  * Use the public API/definitions from CFE and SAMPLE LIB
  */
-#include <cfe.h>
-#include <sample_lib_internal.h>
+#include "cfe.h"
+#include "sample_lib_internal.h"
 
 /*
  * Macro to call a function and check its int32 return code

--- a/unit-test/override_inc/string.h
+++ b/unit-test/override_inc/string.h
@@ -33,7 +33,7 @@
 #ifndef _OVERRIDE_STRING_H_
 #define _OVERRIDE_STRING_H_
 
-#include <OCS_string.h>
+#include "OCS_string.h"
 
 /* ----------------------------------------- */
 /* mappings for declarations in string.h */

--- a/unit-test/override_src/libc_string_stubs.c
+++ b/unit-test/override_src/libc_string_stubs.c
@@ -47,7 +47,7 @@
 /*
  * This is for the prototype of the "OCS_strncpy()" function
  */
-#include <OCS_string.h>
+#include "OCS_string.h"
 
 /* **********************************
  * Implementation of OCS_strncpy stub


### PR DESCRIPTION
**Describe the contribution**
Fix #51 - uses `"` for local includes

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
Jacob Hageman - NASA/GSFC

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES II
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Ind_CLA_form_1219.pdf)
