### PR TITLE
Fix #59, replace direct ref to ArgPtr with macro

### DIFF
--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -68,7 +68,8 @@ typedef struct
 static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context,
                             va_list va)
 {
-    SAMPLE_LIB_Function_TestState_t *State = UserObj;
+    SAMPLE_LIB_Function_TestState_t *State  = UserObj;
+    const char *                     string = UT_Hook_GetArgValueByName(Context, "string", const char *);
 
     /*
      * The OS_printf() stub passes format string as the argument
@@ -76,7 +77,7 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
      * detail would not be needed, but this serves as an example
      * of how it can be done.
      */
-    if (Context->ArgCount > 0 && strcmp(Context->ArgPtr[0], "SAMPLE_LIB_Function called, buffer=\'%s\'\n") == 0)
+    if (Context->ArgCount > 0 && strcmp(string, "SAMPLE_LIB_Function called, buffer=\'%s\'\n") == 0)
     {
         State->format_string_valid = true;
 


### PR DESCRIPTION
**Describe the contribution**
The UT_Hook_GetArgValueByName macro provided by UT assert is the preferred way to get an argument in the current version.  Reading the pointer directly is not advised as it depends on how the stub was actually implemented, whereas the macro should produce consistent results.

Fixes #59

**Testing performed**
Build and run all unit tests, confirm sample_lib test works

**Expected behavior changes**
Hook will continue to work even if stub implementation changes.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Using macro is more readable, more future proof, and reflects current best practice for UT assert hooks.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
