### PR TITLE
sample_lib Integration candidate: 2021-04-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ sample_lib implements SAMPLE_Function, as an example for how to build and link a
 
 ## Version History
 
+### Development Build: v1.2.0-rc1+dev34
+
+- Replace direct ref to ArgPtr with `UT_Hook_GetArgValueByName` macro. Reading the pointer directly is not advised.
+- See <https://github.com/nasa/sample_lib/pull/61> and <https://github.com/nasa/cFS/pull/250>
+
 ### Development Build: v1.2.0-rc1+dev30
 
 - Replace <> with " for local includes

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -32,7 +32,7 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_LIB_BUILD_NUMBER 30 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_LIB_BUILD_NUMBER 34 /*!< Development Build: Number of commits since baseline */
 #define SAMPLE_LIB_BUILD_BASELINE \
     "v1.2.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -68,7 +68,8 @@ typedef struct
 static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context,
                             va_list va)
 {
-    SAMPLE_LIB_Function_TestState_t *State = UserObj;
+    SAMPLE_LIB_Function_TestState_t *State  = UserObj;
+    const char *                     string = UT_Hook_GetArgValueByName(Context, "string", const char *);
 
     /*
      * The OS_printf() stub passes format string as the argument
@@ -76,7 +77,7 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
      * detail would not be needed, but this serves as an example
      * of how it can be done.
      */
-    if (Context->ArgCount > 0 && strcmp(Context->ArgPtr[0], "SAMPLE_LIB_Function called, buffer=\'%s\'\n") == 0)
+    if (Context->ArgCount > 0 && strcmp(string, "SAMPLE_LIB_Function called, buffer=\'%s\'\n") == 0)
     {
         State->format_string_valid = true;
 


### PR DESCRIPTION
## Description 

### PR #60 

Fix #59, replace direct ref to ArgPtr with macro 

The UT_Hook_GetArgValueByName macro provided by UT assert is the preferred way to get an argument in the current version. Reading the pointer directly is not advised as it depends on how the stub was actually implemented, whereas the macro should produce consistent results.

Hook will continue to work even if stub implementation changes.


Using macro is more readable, more future proof, and reflects current best practice for UT assert hooks.


## Context

Part of <https://github.com/nasa/cfs/pull/250>

## Testing

sample_lib Tests <https://github.com/nasa/sample_lib/pull/61/checks>
cFS Bundle Tests <https://github.com/nasa/cfs/issues/250/checks>


## Authors

@jphickey 