### PR TITLE
Corrected minor markdown and comment typos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ To report a vulnerability for the sample_lib subsystem please [submit an issue](
 
 For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy) for additional information.
 
-In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropriate labels for each report. For security related reports, tag the issue with the "security" label.
 
 ## Testing
 

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_cfe_coverage_stubs(sample_lib_overrides
     override_src/libc_string_stubs.c
 )
 
-# Add a coverate test excutable called "sample_lib-ALL" that 
+# Add a coverage test executable called "sample_lib-ALL" that 
 # covers all of the functions in sample_lib.  
 #
 # Also note in a more complex app/lib the coverage test can also

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -110,7 +110,7 @@ void Test_SAMPLE_LIB_Init(void)
      */
 
     /* Set a data buffer for strncpy()
-     * This overriddes what it would normally do */
+     * This overrides what it would normally do */
     UT_SetDataBuffer(UT_KEY(OCS_strncpy), UT_TESTBUFFER, sizeof(UT_TESTBUFFER), false);
 
     /* nominal case should return SUCCESS */

--- a/unit-test/override_src/libc_string_stubs.c
+++ b/unit-test/override_src/libc_string_stubs.c
@@ -31,7 +31,7 @@
 ** Notes:
 ** For most Unit tests this is _NOT_ necessary.  Whenever
 ** possible, FSW code should only call CFE/OSAL/PSP code for
-** which there are already stubs available and the the
+** which there are already stubs available and the
 ** replacements can be made transparently at link time.
 */
 


### PR DESCRIPTION
**Describe the contribution**
Fixed a few minor typos in the text of SECURITY.md, and in the comments of:
- unit-test/CMakeLists.txt
- libc_string_stubs.c 

**Testing performed**
None (non-executable code).

**Expected behavior changes**
None (minor Markdown doc and comments changes only).

**System(s) tested on**
n/a

**Additional context**
n/a

**Code contributions**
n/a