### PR TITLE
Fix #75, Remove explicit filename doxygen comments

### DIFF
--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -20,7 +20,7 @@
 **
 *************************************************************************/
 
-/*! @file sample_lib_version.h
+/*! @file
  * @brief Purpose:
  *
  *  The Sample Lib header file containing version information


### PR DESCRIPTION
**Describe the contribution**
- Fix #75 

**Testing performed**
Make doc, observe no filename warnings

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC