### PR TITLE
Fix #83, Remove unnecessary parentheses around return values.

### DIFF
--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -76,7 +76,7 @@ int32 SAMPLE_LIB_Function(void)
 {
     OS_printf("SAMPLE_LIB_Function called, buffer=\'%s\'\n", SAMPLE_LIB_Buffer);
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 
 } /* End SAMPLE_LIB_Function */
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #83 
Removes parentheses in return statements in sample_lib that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 