### PR TITLE
Fix #88, Remove redundant comments

### DIFF
--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -64,8 +64,7 @@ int32 SAMPLE_LIB_Init(void)
     OS_printf("SAMPLE Lib Initialized.%s\n", SAMPLE_LIB_VERSION_STRING);
 
     return CFE_SUCCESS;
-
-} /* End SAMPLE_LIB_Init */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -77,9 +76,4 @@ int32 SAMPLE_LIB_Function(void)
     OS_printf("SAMPLE_LIB_Function called, buffer=\'%s\'\n", SAMPLE_LIB_Buffer);
 
     return CFE_SUCCESS;
-
-} /* End SAMPLE_LIB_Function */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/inc/OCS_string.h
+++ b/unit-test/inc/OCS_string.h
@@ -32,7 +32,7 @@
 #define OSC_STRING_H
 
 /* ----------------------------------------- */
-/* prototypes normally declared in string.h */
+/* prototypes normally declared in string.h  */
 /* ----------------------------------------- */
 
 extern char *OCS_strncpy(char *dest, const char *src, unsigned long size);

--- a/unit-test/override_inc/string.h
+++ b/unit-test/override_inc/string.h
@@ -34,7 +34,7 @@
 #include "OCS_string.h"
 
 /* ----------------------------------------- */
-/* mappings for declarations in string.h */
+/* mappings for declarations in string.h     */
 /* ----------------------------------------- */
 
 #define strncpy OCS_strncpy

--- a/ut-stubs/sample_lib_stubs.c
+++ b/ut-stubs/sample_lib_stubs.c
@@ -61,8 +61,7 @@ int32 SAMPLE_LIB_Init(void)
      * case configures something different.
      */
     return UT_DEFAULT_IMPL(SAMPLE_LIB_Init);
-
-} /* End SAMPLE_LIB_Init */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -72,4 +71,4 @@ int32 SAMPLE_LIB_Init(void)
 int32 SAMPLE_LIB_Function(void)
 {
     return UT_DEFAULT_IMPL(SAMPLE_LIB_Function);
-} /* End SAMPLE_LIB_Function */
+}


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #88
Removes redundant comments (incl. `/* end of function */`, `/* end if */`, function name in function header comments).
Empty lines before the final closing brace of functions were removed as well, as they were triggering the CI checks.

**Testing performed**
None (comment changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 