### PR TITLE
Fix #94, updating sample_lib to use new versioning system.

### DIFF
--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -27,6 +27,8 @@
 #include "sample_lib_version.h"
 #include "sample_lib_internal.h"
 
+#include "cfe_config.h"
+
 /* for "strncpy()" */
 #include <string.h>
 
@@ -43,6 +45,8 @@ char SAMPLE_LIB_Buffer[SAMPLE_LIB_BUFFER_SIZE];
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SAMPLE_LIB_Init(void)
 {
+    char VersionString[SAMPLE_LIB_CFG_MAX_VERSION_STR_LEN];
+
     /*
      * Call a C library function, like strcpy(), and test its result.
      *
@@ -61,7 +65,10 @@ int32 SAMPLE_LIB_Init(void)
     /* ensure termination */
     SAMPLE_LIB_Buffer[sizeof(SAMPLE_LIB_Buffer) - 1] = 0;
 
-    OS_printf("SAMPLE Lib Initialized.%s\n", SAMPLE_LIB_VERSION_STRING);
+    CFE_Config_GetVersionString(VersionString, SAMPLE_LIB_CFG_MAX_VERSION_STR_LEN, "Sample Lib",
+        SAMPLE_LIB_VERSION, SAMPLE_LIB_BUILD_CODENAME, SAMPLE_LIB_LAST_OFFICIAL);
+
+    OS_printf("SAMPLE Lib Initialized.%s\n", VersionString);
 
     return CFE_SUCCESS;
 }

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -26,16 +26,22 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_LIB_BUILD_NUMBER 32 /*!< Development Build: Number of commits since baseline */
-#define SAMPLE_LIB_BUILD_BASELINE \
-    "v1.3.0-rc4" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_LIB_BUILD_NUMBER     32 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_LIB_BUILD_BASELINE   "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_LIB_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define SAMPLE_LIB_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define SAMPLE_LIB_MAJOR_VERSION 1  /*!< @brief Major version number */
 #define SAMPLE_LIB_MINOR_VERSION 1  /*!< @brief Minor version number */
-#define SAMPLE_LIB_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define SAMPLE_LIB_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define SAMPLE_LIB_LAST_OFFICIAL "v1.1.0"
 
 /*!
  * @brief Mission revision.
@@ -63,13 +69,13 @@
  */
 #define SAMPLE_LIB_VERSION SAMPLE_LIB_BUILD_BASELINE "+dev" SAMPLE_LIB_STR(SAMPLE_LIB_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a sample_lib version string can be.
+ * 
  */
-#define SAMPLE_LIB_VERSION_STRING                       \
-    " Sample Lib DEVELOPMENT BUILD " SAMPLE_LIB_VERSION \
-    ", Last Official Release: v1.1.0" /* For full support please use this version */
+#define SAMPLE_LIB_CFG_MAX_VERSION_STR_LEN 256
 
 #endif /* SAMPLE_LIB_VERSION_H */
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #94.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "SAMPLE_LIB_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC