### PR TITLE
Fix #100, Minor CMake updates + typos clean-up

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -8,6 +8,6 @@ jobs:
   codeql:
     name: Codeql
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: libs/sample_lib
       make: 'make -C build/native/default_cpu1/apps/sample_lib'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-project(CFE_SAMPLE_LIB C)
+cmake_minimum_required(VERSION 3.5)
+project(CFS_SAMPLE_LIB C)
 
 # Create the app module
 add_cfe_app(sample_lib fsw/src/sample_lib.c)

--- a/fsw/src/sample_lib.c
+++ b/fsw/src/sample_lib.c
@@ -50,7 +50,7 @@ int32 SAMPLE_LIB_Init(void)
     /*
      * Call a C library function, like strcpy(), and test its result.
      *
-     * This is primary for a unit test example, to have more than
+     * This is primarily for a unit test example, to have more than
      * one code path to exercise.
      *
      * The specification for strncpy() indicates that it should return
@@ -65,8 +65,8 @@ int32 SAMPLE_LIB_Init(void)
     /* ensure termination */
     SAMPLE_LIB_Buffer[sizeof(SAMPLE_LIB_Buffer) - 1] = 0;
 
-    CFE_Config_GetVersionString(VersionString, SAMPLE_LIB_CFG_MAX_VERSION_STR_LEN, "Sample Lib",
-        SAMPLE_LIB_VERSION, SAMPLE_LIB_BUILD_CODENAME, SAMPLE_LIB_LAST_OFFICIAL);
+    CFE_Config_GetVersionString(VersionString, SAMPLE_LIB_CFG_MAX_VERSION_STR_LEN, "Sample Lib", SAMPLE_LIB_VERSION,
+                                SAMPLE_LIB_BUILD_CODENAME, SAMPLE_LIB_LAST_OFFICIAL);
 
     OS_printf("SAMPLE Lib Initialized.%s\n", VersionString);
 

--- a/fsw/src/sample_lib_version.h
+++ b/fsw/src/sample_lib_version.h
@@ -26,17 +26,19 @@
 
 /* Development Build Macro Definitions */
 
-#define SAMPLE_LIB_BUILD_NUMBER     2 /*!< Development Build: Number of commits since baseline */
-#define SAMPLE_LIB_BUILD_BASELINE   "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
-#define SAMPLE_LIB_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define SAMPLE_LIB_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
+#define SAMPLE_LIB_BUILD_NUMBER 2 /*!< Development Build: Number of commits since baseline */
+#define SAMPLE_LIB_BUILD_BASELINE \
+    "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define SAMPLE_LIB_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle \
+                                                   */
+#define SAMPLE_LIB_BUILD_CODENAME "Equuleus"      /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
-#define SAMPLE_LIB_MAJOR_VERSION 1  /*!< @brief Major version number */
-#define SAMPLE_LIB_MINOR_VERSION 1  /*!< @brief Minor version number */
-#define SAMPLE_LIB_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+#define SAMPLE_LIB_MAJOR_VERSION 1 /*!< @brief Major version number */
+#define SAMPLE_LIB_MINOR_VERSION 1 /*!< @brief Minor version number */
+#define SAMPLE_LIB_REVISION      0 /*!< @brief Revision version number. Value of 0 indicates a development version.*/
 
 /**
  * @brief Last official release.
@@ -71,9 +73,9 @@
 
 /**
  * @brief Max Version String length.
- * 
+ *
  * Maximum length that a sample_lib version string can be.
- * 
+ *
  */
 #define SAMPLE_LIB_CFG_MAX_VERSION_STR_LEN 256
 

--- a/unit-test/coveragetest/coveragetest_sample_lib.c
+++ b/unit-test/coveragetest/coveragetest_sample_lib.c
@@ -67,7 +67,7 @@ static int32 UT_printf_hook(void *UserObj, int32 StubRetcode, uint32 CallCount, 
                             va_list va)
 {
     SAMPLE_LIB_Function_TestState_t *State  = UserObj;
-    const char *                     string = UT_Hook_GetArgValueByName(Context, "string", const char *);
+    const char                      *string = UT_Hook_GetArgValueByName(Context, "string", const char *);
 
     /*
      * The OS_printf() stub passes format string as the argument

--- a/unit-test/inc/OCS_string.h
+++ b/unit-test/inc/OCS_string.h
@@ -28,8 +28,8 @@
 ** strncpy().
 */
 
-#ifndef OSC_STRING_H
-#define OSC_STRING_H
+#ifndef OCS_STRING_H
+#define OCS_STRING_H
 
 /* ----------------------------------------- */
 /* prototypes normally declared in string.h  */

--- a/unit-test/override_src/libc_string_stubs.c
+++ b/unit-test/override_src/libc_string_stubs.c
@@ -76,6 +76,6 @@ char *OCS_strncpy(char *dst, const char *src, unsigned long size)
         memset(&dst[CopySize], 0, size - CopySize);
     }
 
-    /* normal response is to return a pointer to the source */
+    /* normal response is to return a pointer to the destination */
     return dst;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #100 
  - add `cmake_minimum_required`
  - rename CMake project from `CFE_SAMPLE_LIB` to `CFS_SAMPLE_LIB` (I think this is more correctly thought of as a cFS add-on rather than just a cFE add-on these days)
  - correct a few typos
  - formatting is applied as per the `.clang-format` file in the cFS bundle

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Aligns CMake file with expectations + standard cFS pattern & correct typos.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt